### PR TITLE
OAuth2를 이용하여 Google, Github로 로그인 구현 및 Jasypt 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,18 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    testImplementation 'org.springframework.security:spring-security-test'
+    compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/judgeoverflow/config/JasyptConfig.java
+++ b/src/main/java/judgeoverflow/config/JasyptConfig.java
@@ -17,11 +17,12 @@ public class JasyptConfig {
         PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
         SimpleStringPBEConfig config = new SimpleStringPBEConfig();
         config.setPassword(encryptorPassword);//암호화 키
-        config.setAlgorithm("PBEWithMD5AndDES");//암호화 알고리즘
+        config.setAlgorithm("PBEWITHHMACSHA512ANDAES_256");//암호화 알고리즘
         config.setKeyObtentionIterations("1000");
         config.setPoolSize("1");
         config.setProviderName("SunJCE");
         config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.RandomIvGenerator");
         config.setStringOutputType("base64");
         encryptor.setConfig(config);
         return encryptor;

--- a/src/main/java/judgeoverflow/config/JasyptConfig.java
+++ b/src/main/java/judgeoverflow/config/JasyptConfig.java
@@ -1,0 +1,30 @@
+package judgeoverflow.config;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JasyptConfig {
+    @Value("${jasypt.encryptor.password}")
+    private String encryptorPassword;
+
+    @Bean("jasyptStringEncryptor")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(encryptorPassword);//암호화 키
+        config.setAlgorithm("PBEWithMD5AndDES");//암호화 알고리즘
+        config.setKeyObtentionIterations("1000");
+        config.setPoolSize("1");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setStringOutputType("base64");
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+
+}

--- a/src/main/java/judgeoverflow/config/SecurityConfig.java
+++ b/src/main/java/judgeoverflow/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package judgeoverflow.config;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import judgeoverflow.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**").permitAll()
+                        .requestMatchers("/api/v1/**").hasRole("USER")
+                        .anyRequest().authenticated()
+                )
+                .logout(logout -> logout
+                        .logoutSuccessUrl("/"))
+                .oauth2Login(oauth2Login -> oauth2Login
+                        .userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint
+                                .userService(customOAuth2UserService) // 커스텀 서비스 등록
+                        )
+                );
+        return http.build();
+    }
+}

--- a/src/main/java/judgeoverflow/config/SecurityConfig.java
+++ b/src/main/java/judgeoverflow/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -21,13 +22,14 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**").permitAll()
+                        .requestMatchers("/css/**", "/images/**", "/js/**", "/h2-console/**").permitAll()
                         .requestMatchers("/api/v1/**").hasRole("USER")
                         .anyRequest().authenticated()
                 )
                 .logout(logout -> logout
                         .logoutSuccessUrl("/"))
                 .oauth2Login(oauth2Login -> oauth2Login
+                        .defaultSuccessUrl("/")
                         .userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint
                                 .userService(customOAuth2UserService) // 커스텀 서비스 등록
                         )

--- a/src/main/java/judgeoverflow/config/SecurityConfig.java
+++ b/src/main/java/judgeoverflow/config/SecurityConfig.java
@@ -1,14 +1,11 @@
 package judgeoverflow.config;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
 import judgeoverflow.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -22,7 +19,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/css/**", "/images/**", "/js/**", "/h2-console/**").permitAll()
+                        .requestMatchers("/", "/css/**", "/images/**", "/js/**").permitAll()
                         .requestMatchers("/api/v1/**").hasRole("USER")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/judgeoverflow/controller/MainController.java
+++ b/src/main/java/judgeoverflow/controller/MainController.java
@@ -1,24 +1,26 @@
 package judgeoverflow.controller;
 
-import java.util.Collections;
-import java.util.Map;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
-@RestController
+@Controller
 public class MainController {
 
     @GetMapping("/")
-    public Map<String, Object> home(@AuthenticationPrincipal OAuth2User principal) {
+    public String home(@AuthenticationPrincipal OAuth2User principal, Model model) {
         // principal이 null인 경우 (미인증 사용자) 빈 맵을 반환합니다.
         if (principal == null) {
-            return Collections.emptyMap();
+            return "index";
         }
         // principal에서 사용자 속성을 가져올 수 있습니다.
-        return principal.getAttributes();
+//        return principal.getAttributes();
+
+        // 필요한 정보만 모델에 추가
+        model.addAttribute("name", principal.getAttribute("name"));
+        model.addAttribute("email", principal.getAttribute("email"));
+        return "index";
     }
 }

--- a/src/main/java/judgeoverflow/controller/MainController.java
+++ b/src/main/java/judgeoverflow/controller/MainController.java
@@ -1,5 +1,6 @@
 package judgeoverflow.controller;
 
+import java.util.Collections;
 import java.util.Map;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -13,6 +14,10 @@ public class MainController {
 
     @GetMapping("/")
     public Map<String, Object> home(@AuthenticationPrincipal OAuth2User principal) {
+        // principal이 null인 경우 (미인증 사용자) 빈 맵을 반환합니다.
+        if (principal == null) {
+            return Collections.emptyMap();
+        }
         // principal에서 사용자 속성을 가져올 수 있습니다.
         return principal.getAttributes();
     }

--- a/src/main/java/judgeoverflow/controller/MainController.java
+++ b/src/main/java/judgeoverflow/controller/MainController.java
@@ -1,0 +1,19 @@
+package judgeoverflow.controller;
+
+import java.util.Map;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MainController {
+
+    @GetMapping("/")
+    public Map<String, Object> home(@AuthenticationPrincipal OAuth2User principal) {
+        // principal에서 사용자 속성을 가져올 수 있습니다.
+        return principal.getAttributes();
+    }
+}

--- a/src/main/java/judgeoverflow/dto/OAuthAttributes.java
+++ b/src/main/java/judgeoverflow/dto/OAuthAttributes.java
@@ -31,9 +31,13 @@ public class OAuthAttributes {
     }
 
     private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        String email = (String) attributes.get("email");
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("GitHub에서 이메일을 제공하지 않았습니다. OAuth 앱 설정에서 user:email scope를 요청해야 합니다.");
+        }
         return OAuthAttributes.builder()
                 .name((String) attributes.get("name"))
-                .email((String) attributes.get("email"))
+                .email(email)
                 .picture((String) attributes.get("picture"))
                 .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)
@@ -52,6 +56,9 @@ public class OAuthAttributes {
 
 
     public Committer toEntity() {
+        if (email == null || email.isBlank()) {
+            throw new IllegalStateException("이메일은 필수 항목입니다. OAuth 제공자로부터 이메일을 받지 못했습니다.");
+        }
         return Committer.builder()
                 .name(name)
                 .email(email)

--- a/src/main/java/judgeoverflow/dto/OAuthAttributes.java
+++ b/src/main/java/judgeoverflow/dto/OAuthAttributes.java
@@ -27,7 +27,11 @@ public class OAuthAttributes {
         if ("github".equals(registrationId)) {
             return ofGithub(userNameAttributeName, attributes);
         }
-        return ofGoogle(userNameAttributeName, attributes);
+        if ("google".equals(registrationId)) {
+            return ofGoogle(userNameAttributeName, attributes);
+        }
+//        return ofGoogle(userNameAttributeName, attributes);
+        throw new IllegalArgumentException("지원하지 않는 OAuth 제공자입니다: " + registrationId);
     }
 
     private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
@@ -68,6 +72,9 @@ public class OAuthAttributes {
 
 
     public Committer toEntity() {
+        if (name == null || name.isBlank()) {
+            throw new IllegalStateException("이름은 필수 항목입니다. OAuth 제공자로부터 이름을 받지 못했습니다.");
+        }
         if (email == null || email.isBlank()) {
             throw new IllegalStateException("이메일은 필수 항목입니다. OAuth 제공자로부터 이메일을 받지 못했습니다.");
         }

--- a/src/main/java/judgeoverflow/dto/OAuthAttributes.java
+++ b/src/main/java/judgeoverflow/dto/OAuthAttributes.java
@@ -33,7 +33,7 @@ public class OAuthAttributes {
     private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
         String email = (String) attributes.get("email");
         if (email == null || email.isBlank()) {
-            throw new IllegalArgumentException("GitHub에서 이메일을 제공하지 않았습니다. OAuth 앱 설정에서 user:email scope를 요청해야 합니다.");
+            throw new IllegalArgumentException("Google에서 이메일을 제공하지 않았습니다.");
         }
         return OAuthAttributes.builder()
                 .name((String) attributes.get("name"))
@@ -45,9 +45,13 @@ public class OAuthAttributes {
     }
 
     private static OAuthAttributes ofGithub(String userNameAttributeName, Map<String, Object> attributes) {
+        String email = (String) attributes.get("email");
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("GitHub에서 이메일을 제공하지 않았습니다. OAuth 앱 설정에서 user:email scope를 요청해야 합니다.");
+        }
         return OAuthAttributes.builder()
                 .name((String) attributes.get("name"))
-                .email((String) attributes.get("email"))
+                .email(email)
                 .picture((String) attributes.get("avatar_url"))
                 .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)

--- a/src/main/java/judgeoverflow/dto/OAuthAttributes.java
+++ b/src/main/java/judgeoverflow/dto/OAuthAttributes.java
@@ -30,7 +30,6 @@ public class OAuthAttributes {
         if ("google".equals(registrationId)) {
             return ofGoogle(userNameAttributeName, attributes);
         }
-//        return ofGoogle(userNameAttributeName, attributes);
         throw new IllegalArgumentException("지원하지 않는 OAuth 제공자입니다: " + registrationId);
     }
 

--- a/src/main/java/judgeoverflow/dto/OAuthAttributes.java
+++ b/src/main/java/judgeoverflow/dto/OAuthAttributes.java
@@ -1,0 +1,62 @@
+package judgeoverflow.dto;
+
+import java.util.Map;
+import judgeoverflow.entity.Committer;
+import judgeoverflow.entity.CommitterRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuthAttributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String picture;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email, String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        if ("github".equals(registrationId)) {
+            return ofGithub(userNameAttributeName, attributes);
+        }
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .picture((String) attributes.get("picture"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    private static OAuthAttributes ofGithub(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .picture((String) attributes.get("avatar_url"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+
+    public Committer toEntity() {
+        return Committer.builder()
+                .name(name)
+                .email(email)
+                .profileImage(picture)
+                .role(CommitterRole.USER) // 기본 권한을 USER로 설정
+                .build();
+    }
+}

--- a/src/main/java/judgeoverflow/dto/OAuthAttributes.java
+++ b/src/main/java/judgeoverflow/dto/OAuthAttributes.java
@@ -31,12 +31,16 @@ public class OAuthAttributes {
     }
 
     private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        String name = (String) attributes.get("name");
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Google에서 이름을 제공하지 않았습니다.");
+        }
         String email = (String) attributes.get("email");
         if (email == null || email.isBlank()) {
             throw new IllegalArgumentException("Google에서 이메일을 제공하지 않았습니다.");
         }
         return OAuthAttributes.builder()
-                .name((String) attributes.get("name"))
+                .name(name)
                 .email(email)
                 .picture((String) attributes.get("picture"))
                 .attributes(attributes)
@@ -45,12 +49,16 @@ public class OAuthAttributes {
     }
 
     private static OAuthAttributes ofGithub(String userNameAttributeName, Map<String, Object> attributes) {
+        String name = (String) attributes.get("name");
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("GitHub에서 이름을 제공하지 않았습니다.");
+        }
         String email = (String) attributes.get("email");
         if (email == null || email.isBlank()) {
             throw new IllegalArgumentException("GitHub에서 이메일을 제공하지 않았습니다. OAuth 앱 설정에서 user:email scope를 요청해야 합니다.");
         }
         return OAuthAttributes.builder()
-                .name((String) attributes.get("name"))
+                .name(name)
                 .email(email)
                 .picture((String) attributes.get("avatar_url"))
                 .attributes(attributes)

--- a/src/main/java/judgeoverflow/entity/Committer.java
+++ b/src/main/java/judgeoverflow/entity/Committer.java
@@ -1,0 +1,46 @@
+package judgeoverflow.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Committer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+    private String profileImage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CommitterRole role;
+
+    public Committer update(String name, String profileImage) {
+        this.name = name;
+        this.profileImage = profileImage;
+        return this;
+    }
+}

--- a/src/main/java/judgeoverflow/entity/Committer.java
+++ b/src/main/java/judgeoverflow/entity/Committer.java
@@ -23,7 +23,6 @@ public class Committer {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private String username;
 
     @Column(nullable = false)

--- a/src/main/java/judgeoverflow/entity/Committer.java
+++ b/src/main/java/judgeoverflow/entity/Committer.java
@@ -29,7 +29,7 @@ public class Committer {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
     private String profileImage;
@@ -38,9 +38,10 @@ public class Committer {
     @Column(nullable = false)
     private CommitterRole role;
 
-    public Committer update(String name, String profileImage) {
+    public Committer update(String name, String profileImage, String email) {
         this.name = name;
         this.profileImage = profileImage;
+        this.email = email;
         return this;
     }
 }

--- a/src/main/java/judgeoverflow/entity/CommitterRole.java
+++ b/src/main/java/judgeoverflow/entity/CommitterRole.java
@@ -1,0 +1,13 @@
+package judgeoverflow.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommitterRole {
+    ADMIN("ADMIN"),
+    USER("USER");
+
+    private final String role;
+}

--- a/src/main/java/judgeoverflow/repository/CommitterRepository.java
+++ b/src/main/java/judgeoverflow/repository/CommitterRepository.java
@@ -1,0 +1,11 @@
+package judgeoverflow.repository;
+
+import java.util.Optional;
+import judgeoverflow.entity.Committer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommitterRepository extends JpaRepository<Committer, Long> {
+    Optional<Committer> findByEmail(String email);
+}

--- a/src/main/java/judgeoverflow/service/CustomOAuth2UserService.java
+++ b/src/main/java/judgeoverflow/service/CustomOAuth2UserService.java
@@ -1,0 +1,51 @@
+package judgeoverflow.service;
+
+import java.util.Collections;
+import judgeoverflow.dto.OAuthAttributes;
+import judgeoverflow.entity.Committer;
+import judgeoverflow.repository.CommitterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final CommitterRepository committerRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        Committer user = saveOrUpdate(attributes);
+
+        // 세션에 사용자 정보를 저장하는 로직은 여기에 추가할 수 있습니다.
+        // httpSession.setAttribute("user", new SessionUser(user));
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(user.getRole().name())),
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey());
+    }
+
+    private Committer saveOrUpdate(OAuthAttributes attributes) {
+        Committer committer = committerRepository.findByEmail(attributes.getEmail())
+                .map(entity -> entity.update(attributes.getName(), attributes.getPicture()))
+                .orElse(attributes.toEntity());
+
+        return committerRepository.save(committer);
+    }
+}

--- a/src/main/java/judgeoverflow/service/CustomOAuth2UserService.java
+++ b/src/main/java/judgeoverflow/service/CustomOAuth2UserService.java
@@ -36,8 +36,12 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         // 세션에 사용자 정보를 저장하는 로직은 여기에 추가할 수 있습니다.
         // httpSession.setAttribute("user", new SessionUser(user));
 
+        String authority = user.getRole().name();
+        if (!authority.startsWith("ROLE_")) {
+            authority = "ROLE_" + authority;
+        }
         return new DefaultOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority(user.getRole().name())),
+                Collections.singleton(new SimpleGrantedAuthority(authority)),
                 attributes.getAttributes(),
                 attributes.getNameAttributeKey());
     }
@@ -48,7 +52,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             throw new OAuth2AuthenticationException("GitHub에서 이메일을 반환하지 않았습니다. user:email scope를 요청하고 /user/emails에서 primary 이메일을 조회하는 보강이 필요합니다.");
         }
         Committer committer = committerRepository.findByEmail(email)
-                .map(entity -> entity.update(attributes.getName(), attributes.getPicture()))
+                .map(entity -> entity.update(attributes.getName(), attributes.getPicture(), attributes.getEmail()))
                 .orElse(attributes.toEntity());
 
         return committerRepository.save(committer);

--- a/src/main/java/judgeoverflow/service/CustomOAuth2UserService.java
+++ b/src/main/java/judgeoverflow/service/CustomOAuth2UserService.java
@@ -13,6 +13,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -42,7 +43,11 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     }
 
     private Committer saveOrUpdate(OAuthAttributes attributes) {
-        Committer committer = committerRepository.findByEmail(attributes.getEmail())
+        String email = attributes.getEmail();
+        if (!StringUtils.hasText(email)) {
+            throw new OAuth2AuthenticationException("GitHub에서 이메일을 반환하지 않았습니다. user:email scope를 요청하고 /user/emails에서 primary 이메일을 조회하는 보강이 필요합니다.");
+        }
+        Committer committer = committerRepository.findByEmail(email)
                 .map(entity -> entity.update(attributes.getName(), attributes.getPicture()))
                 .orElse(attributes.toEntity());
 

--- a/src/main/java/judgeoverflow/service/CustomOAuth2UserService.java
+++ b/src/main/java/judgeoverflow/service/CustomOAuth2UserService.java
@@ -49,7 +49,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private Committer saveOrUpdate(OAuthAttributes attributes) {
         String email = attributes.getEmail();
         if (!StringUtils.hasText(email)) {
-            throw new OAuth2AuthenticationException("GitHub에서 이메일을 반환하지 않았습니다. user:email scope를 요청하고 /user/emails에서 primary 이메일을 조회하는 보강이 필요합니다.");
+            throw new OAuth2AuthenticationException("OAuth 제공자에서 이메일을 반환하지 않았습니다. OAuth 앱 설정에서 user:email scope를 요청해야 합니다.");
         }
         Committer committer = committerRepository.findByEmail(email)
                 .map(entity -> entity.update(attributes.getName(), attributes.getPicture(), attributes.getEmail()))

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,17 +8,19 @@ spring:
       client:
         registration:
           google:
-            client-id: ENC(sT5b+p+AxJNQUu2s82LfB8oyTU+zH1OTUdQcbPizcrZ2NAsICmGkz/mHhz8tMn1OJODvzB5kz6v95y7GLGUm2l87WlmPlXiDC1roADdhE3U=)
-            client-secret: ENC(7tXgwBtOYWmaAP8jqalGALBfxtLIfZnzEUWsS6mIShz5NAvABONfRxRv9oOv6E+1)
+            client-id: ENC(a1ZwUcY0/bhNoUXklI+AAN5S6UH9Ou6C5BwIHMUa7kBiCaeiPBug5aDAdhDmLfsCKFYc+TQRdXUiyz1OERxgl3PIq66At8BYa4sPpUFnt9jSmBaObWPa+8SLJvpeDlMbkEgqXJhJ5WlkQbCBLycfLw==)
+            client-secret: ENC(pvII7YF9JYTHc/CwFhyOBfgCm60R3hjSMEl26Y1K6r7lg/LRwBeUQKHMQpvH8xBgojbaOTnfzsBkk/IssI33qMBvjYU1arac9dA0G14v80M=)
           github:
-            client-id: ENC(gnaMlgyhtzKK0a2fRCP+y7bniBtja5FbhH2NL+bD/+4=)
-            client-secret: ENC(tQ6672CsqA2+vKy6iXuRmi8bOGjgKy0fkVv3nkshRFE0s8VBmk8+ovY+eIJ1MmrO4ovPOhtzMb0=)
+            client-id: ENC(+uvt50eXMLftMwES9Z8iRxmJoA1hquNZpJEHwkusaiEyEoDgcdrec/w6/JOb9bExBN0eonGHcvA3N+HdWet7zQ==)
+            client-secret: ENC(9EYDzWTL+RG+XgfTIjZwZQgu7q6MoENNPBezk6SJlEr5wiJKZW77Scbr6FVRDZds9AJOzNpi5fCe5SuYkncg2QwCjMbaVPewR8nUWpaCxpQ=)
+            scope:
+              - user:email
 
   # DB
   datasource:
     url: jdbc:postgresql://localhost:5432/judgeoverflow
-    username: ENC(xrZSYxAwYBYDtP8kL+dhrqIYa+xKL5DF)
-    password: ENC(fN1+BOHdDcK5vEnIonKxWkd2mXe/NjkkgQIoQyn+Ce4=)
+    username: ENC(zi2rzPiqq7WKfbVD4rhFbIzFx8SqMHMiTXUpZQjhXVveY/2xjm05LJxnM+GEVrSP)
+    password: ENC(J8GMrasqQQ1hYC0fSJmMS65nVa6LcEwmMTb/p+Jtc6r0z4NkDCvv7nZ9XmOYRzcJ8fF2EtDFQfxNIyzEvZQStA==)
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,32 @@
 spring:
   application:
     name: judgeoverflow
+
+  # Security
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ENC(sT5b+p+AxJNQUu2s82LfB8oyTU+zH1OTUdQcbPizcrZ2NAsICmGkz/mHhz8tMn1OJODvzB5kz6v95y7GLGUm2l87WlmPlXiDC1roADdhE3U=)
+            client-secret: ENC(7tXgwBtOYWmaAP8jqalGALBfxtLIfZnzEUWsS6mIShz5NAvABONfRxRv9oOv6E+1)
+          github:
+            client-id: ENC(gnaMlgyhtzKK0a2fRCP+y7bniBtja5FbhH2NL+bD/+4=)
+            client-secret: ENC(tQ6672CsqA2+vKy6iXuRmi8bOGjgKy0fkVv3nkshRFE0s8VBmk8+ovY+eIJ1MmrO4ovPOhtzMb0=)
+
+  # DB
+  datasource:
+    url: jdbc:postgresql://localhost:5432/judgeoverflow
+    username: ENC(xrZSYxAwYBYDtP8kL+dhrqIYa+xKL5DF)
+    password: ENC(fN1+BOHdDcK5vEnIonKxWkd2mXe/NjkkgQIoQyn+Ce4=)
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+
+jasypt:
+  encryptor:
+    bean: jasyptStringEncryptor

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,10 +1,21 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>JudgeOverFlow</title>
 </head>
 <body>
-    <h1>Welcome to JudgeOverFlow!</h1>
+<h1>Welcome to JudgeOverFlow!</h1>
+<div sec:authorize="isAuthenticated()">
+    <p>환영합니다, <span sec:authentication="name">사용자</span>님!</p>
+    <form th:action="@{/logout}" method="post">
+        <button type="submit">로그아웃</button>
+    </form>
+</div>
+<div sec:authorize="!isAuthenticated()">
+    <p>로그인하여 서비스를 이용하세요.</p>
+    <a th:href="@{/oauth2/authorization/google}">Google 로그인</a>
+    <a th:href="@{/oauth2/authorization/github}">GitHub 로그인</a>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <h1>Welcome to JudgeOverFlow!</h1>
+</body>
+</html>

--- a/src/test/java/judgeoverflow/config/JasyptConfigTest.java
+++ b/src/test/java/judgeoverflow/config/JasyptConfigTest.java
@@ -17,44 +17,61 @@ public class JasyptConfigTest {
     void setUp() {
         encryptor = new PooledPBEStringEncryptor();
         SimpleStringPBEConfig config = new SimpleStringPBEConfig();
-        config.setPassword(ENCRYPT_KEY);
-        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setPassword(ENCRYPT_KEY);//암호화 키
+        config.setAlgorithm("PBEWITHHMACSHA512ANDAES_256");//암호화 알고리즘
         config.setKeyObtentionIterations("1000");
         config.setPoolSize("1");
         config.setProviderName("SunJCE");
         config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
-        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.RandomIvGenerator");
         config.setStringOutputType("base64");
         encryptor.setConfig(config);
     }
 
     @Test
-    @DisplayName("데이터베이스 설정 암호화 테스트")
+    @DisplayName("설정 암호화 테스트")
     void encryptDatabaseConfig() {
         // given
-        String url = "jdbc:postgresql://localhost:5432/your_database_name";
+        String googleId = "googleId";
+        String googleSecret = "googleSecret";
+        String githubId = "githubId";
+        String githubSecret = "githubSecret";
+//        String url = "jdbc:postgresql://localhost:5432/your_database_name";
         String username = "username";
         String password = "password";
 
         // when
-        String encryptedUrl = encryptor.encrypt(url);
+        String encryptedGoogleId = encryptor.encrypt(googleId);
+        String encryptedGoogleSecret = encryptor.encrypt(googleSecret);
+        String encryptedGithubId = encryptor.encrypt(githubId);
+        String encryptedGithubSecret = encryptor.encrypt(githubSecret);
+//        String encryptedUrl = encryptor.encrypt(url);
         String encryptedUsername = encryptor.encrypt(username);
         String encryptedPassword = encryptor.encrypt(password);
 
         // then
-        assertThat(encryptor.decrypt(encryptedUrl)).isEqualTo(url);
+        assertThat(encryptedGoogleId).isNotEqualTo(googleId);
+        assertThat(encryptedGoogleSecret).isNotEqualTo(googleSecret);
+        assertThat(encryptedGithubId).isNotEqualTo(githubId);
+        assertThat(encryptedGithubSecret).isNotEqualTo(githubSecret);
+//        assertThat(encryptor.decrypt(encryptedUrl)).isEqualTo(url);
         assertThat(encryptor.decrypt(encryptedUsername)).isEqualTo(username);
         assertThat(encryptor.decrypt(encryptedPassword)).isEqualTo(password);
 
         // 암호화된 설정값 출력
         System.out.println("====== Encrypted Database Configuration ======");
-        System.out.println("URL: ENC(" + encryptedUrl + ")");
+        System.out.println("Google ID: ENC(" + encryptedGoogleId + ")");
+        System.out.println("Google Secret: ENC(" + encryptedGoogleSecret + ")");
+        System.out.println("Github ID: ENC(" + encryptedGithubId + ")");
+        System.out.println("Github Secret: ENC(" + encryptedGithubSecret + ")");
+//        System.out.println("URL: ENC(" + encryptedUrl + ")");
         System.out.println("Username: ENC(" + encryptedUsername + ")");
         System.out.println("Password: ENC(" + encryptedPassword + ")");
     }
 
     @Test
     @DisplayName("문자열 암호화 및 복호화 테스트")
+    @Deprecated
     void encryptAndDecrypt() {
         // given
         String plainText = "plainText";

--- a/src/test/java/judgeoverflow/config/JasyptConfigTest.java
+++ b/src/test/java/judgeoverflow/config/JasyptConfigTest.java
@@ -1,0 +1,73 @@
+package judgeoverflow.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class JasyptConfigTest {
+    private PooledPBEStringEncryptor encryptor;
+
+    private final String ENCRYPT_KEY = "password";
+
+    @BeforeEach
+    void setUp() {
+        encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(ENCRYPT_KEY);
+        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setKeyObtentionIterations("1000");
+        config.setPoolSize("1");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator");
+        config.setStringOutputType("base64");
+        encryptor.setConfig(config);
+    }
+
+    @Test
+    @DisplayName("데이터베이스 설정 암호화 테스트")
+    void encryptDatabaseConfig() {
+        // given
+        String url = "jdbc:postgresql://localhost:5432/your_database_name";
+        String username = "username";
+        String password = "password";
+
+        // when
+        String encryptedUrl = encryptor.encrypt(url);
+        String encryptedUsername = encryptor.encrypt(username);
+        String encryptedPassword = encryptor.encrypt(password);
+
+        // then
+        assertThat(encryptor.decrypt(encryptedUrl)).isEqualTo(url);
+        assertThat(encryptor.decrypt(encryptedUsername)).isEqualTo(username);
+        assertThat(encryptor.decrypt(encryptedPassword)).isEqualTo(password);
+
+        // 암호화된 설정값 출력
+        System.out.println("====== Encrypted Database Configuration ======");
+        System.out.println("URL: ENC(" + encryptedUrl + ")");
+        System.out.println("Username: ENC(" + encryptedUsername + ")");
+        System.out.println("Password: ENC(" + encryptedPassword + ")");
+    }
+
+    @Test
+    @DisplayName("문자열 암호화 및 복호화 테스트")
+    void encryptAndDecrypt() {
+        // given
+        String plainText = "plainText";
+
+        // when
+        String encryptedText = encryptor.encrypt(plainText);
+        String decryptedText = encryptor.decrypt(encryptedText);
+
+        // then
+        assertThat(decryptedText).isEqualTo(plainText);
+        assertThat(encryptedText).isNotEqualTo(plainText);
+
+        // 암호화된 설정값 출력
+        System.out.println("plainText: ENC(" + encryptedText + ")");
+    }
+}


### PR DESCRIPTION
# 📌 개요 (Summary)
Spring Security OAauth2로 Google과 Github로 로그인을 추가해 유저가 별도의 회원가입 없이 Google과 Github의 기존 계정으로 로그인할 수 있어 접근성을 높였습니다.

Jasypt로 DB 접속정보, API Key 등을 암호화해 Git과 같은 버전 관리 시스템에 민감한 정보가 그대로 노출되는 것을 방지하여 보안을 강화했습니다.

OAuth2 로그인 후 리디렉션 경로를 명시적으로 지정하고, 인증되지 않은 사용자가 메인 페이지에 접근할 수 있도록 보안 설정을 수정하여 사용자 경험을 개선했습니다.

# ✨ 변경사항 (Changes)

**OAuth2 소셜 로그인 구현**
- `CustomOAuth2UserService`를 구현하여 Google 및 GitHub 로그인 시 사용자 정보를 가져와 처리합니다.
- `CommitterRepository`를 통해 이메일을 기준으로 사용자를 조회하고, 신규 사용자인 경우 DB에 저장, 기존 사용자인 경우 정보를 업데이트합니다.
- `OAuthAttributes` DTO를 사용하여 소셜 플랫폼별로 상이한 사용자 정보 구조를 `Committer` 엔티티에 맞게 표준화했습니다.

**설정 파일 암호화 (Jasypt 적용)**
- `JasyptConfig`를 추가하여 `application.yaml` 내의 민감한 정보(OAuth Client 정보, DB 계정 등)를 암호화했습니다.

**도메인 모델링 및 보안 설정**
- 사용자 정보를 관리하기 위한 `Committer` 엔티티와 `CommitterRole` Enum을 정의했습니다.
- `SecurityConfig`에서 `CustomOAuth2UserService`를 사용하도록 설정하고, URL별 접근 권한을 명시적으로 구성했습니다.

**로그인 흐름 및 메인 페이지 접근성 개선**
- 로그인 성공 후 리디렉션
  - `SecurityConfig`에 `.defaultSuccessUrl("/")`를 추가하여, OAuth2 로그인 성공 시 사용자가 메인 페이지로 자동 리디렉션되도록 설정했습니다.
- 메인 페이지 접근 권한 수정
  - 인증되지 않은 사용자도 메인 페이지(`/`)에 접근할 수 있도록 `SecurityConfig`의 `authorizeHttpRequests` 설정을 `permitAll`로 변경했습니다.
  - `MainController`에서 `@AuthenticationPrincipal`이 `null`일 경우(미인증 사용자)를 대비한 로직을 추가하여, `NullPointerException` 발생을 방지하고 빈 응답을 반환하도록 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google/GitHub OAuth2 로그인·인증 흐름, 사용자 자동 생성·갱신, 홈 페이지(로그인/로그아웃 포함) 추가
  * 커미터(사용자) 엔티티·역할 모델 및 이메일 기반 조회 기능과 관련 저장소/서비스 추가

* **Security**
  * 접근 규칙·로그아웃·OAuth2 성공 처리 구성 적용
  * 설정값 암호화/복호화 지원(Jasypt) 및 암호화 구성 추가

* **Tests**
  * 암호화 구성에 대한 단위 테스트 추가

* **Chores**
  * 템플릿 엔진·보안·OAuth2·암호화 관련 의존성 추가 및 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->