### PR TITLE
Google OAuth2 로그인 시 사용자 정보를 DB에 저장하도록 OIDC UserService 추가

### DIFF
--- a/src/main/java/judgeoverflow/config/SecurityConfig.java
+++ b/src/main/java/judgeoverflow/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package judgeoverflow.config;
 
 import judgeoverflow.service.CustomOAuth2UserService;
+import judgeoverflow.service.CustomOidcUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomOidcUserService customOidcUserService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -28,7 +30,8 @@ public class SecurityConfig {
                 .oauth2Login(oauth2Login -> oauth2Login
                         .defaultSuccessUrl("/")
                         .userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint
-                                .userService(customOAuth2UserService) // 커스텀 서비스 등록
+                                .userService(customOAuth2UserService) // OAuth
+                                .oidcUserService(customOidcUserService) // Google OIDC
                         )
                 );
         return http.build();

--- a/src/main/java/judgeoverflow/entity/Committer.java
+++ b/src/main/java/judgeoverflow/entity/Committer.java
@@ -23,6 +23,7 @@ public class Committer {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column
     private String username;
 
     @Column(nullable = false)
@@ -31,6 +32,7 @@ public class Committer {
     @Column(nullable = false, unique = true)
     private String email;
 
+    @Column
     private String profileImage;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,6 @@
 spring:
   application:
     name: judgeoverflow
-
   # Security
   security:
     oauth2:
@@ -15,7 +14,6 @@ spring:
             client-secret: ENC(9EYDzWTL+RG+XgfTIjZwZQgu7q6MoENNPBezk6SJlEr5wiJKZW77Scbr6FVRDZds9AJOzNpi5fCe5SuYkncg2QwCjMbaVPewR8nUWpaCxpQ=)
             scope:
               - user:email
-
   # DB
   datasource:
     url: jdbc:postgresql://localhost:5432/judgeoverflow
@@ -32,3 +30,7 @@ spring:
 jasypt:
   encryptor:
     bean: jasyptStringEncryptor
+
+#logging:
+#  level:
+#    org.springframework.security: DEBUG


### PR DESCRIPTION
# 📌 개요 (Summary)
Google OAuth2(OIDC) 로그인 시 Spring Security가 기본 OIDC UserService만 사용하여, 로그인은 성공하지만 사용자 정보가 DB(`committer` 테이블)에 저장되지 않는 문제가 있었습니다.  
이번 PR에서는 Google(OIDC)과 GitHub(OAuth2) 인증 흐름을 분리하여, 두 경우 모두 커스텀 UserService를 거치면서 `Committer` 엔티티를 upsert 하도록 개선했습니다.

# ✨ 변경사항 (Changes)
SecurityConfig
- `oauth2Login().userInfoEndpoint()` 설정에서
  - 일반 OAuth2 클라이언트(GitHub)는 `CustomOAuth2UserService`를 사용
  - OIDC 클라이언트(Google)는 신규 `CustomOidcUserService`를 사용하도록 설정
- 필요에 따라 폼 로그인/HTTP Basic 비활성화 및 `/`를 OAuth2 로그인 시작 페이지로 사용 가능하도록 구성

Committer Entity
- OAuth2/OIDC로부터 전달받는 사용자 정보(name, email, profileImage, role)를 저장/갱신하기 위한 필드 및 제약 조건 정비
- `update(String name, String profileImage, String email)` 메서드를 통해 이메일 기준 기존 사용자 정보 갱신 로직 재사용

CustomOAuth2UserService (기존, OAuth2 전용)
- GitHub 등 일반 OAuth2 로그인에서만 사용되도록 역할 명확화
- `OAuthAttributes`를 활용해 provider별 attribute를 매핑하고, 이메일 기준으로 `Committer`를 조회 후 upsert
- 저장된 `Committer`의 role을 사용해 `DefaultOAuth2User` 생성

CustomOidcUserService (신규, Google OIDC 전용)
- `OAuth2UserService<OidcUserRequest, OidcUser>` 구현
- 기본 `OidcUserService`에 위임해 ID 토큰 + UserInfo를 로드한 뒤, `OAuthAttributes`로 매핑
- 이메일 기준으로 `Committer` 엔티티 upsert 후 DB 저장
- 저장된 `Committer`의 role을 사용해 `DefaultOidcUser` 생성
- 로그 추가: `loadUser`, `saveOrUpdate`, `committer saved` 등

application.yaml
- JPA/로깅 설정을 보완하여 OAuth2/OIDC 로그인 시 Hibernate SQL 로그(INSERT 쿼리 등)를 확인 가능하도록 정리
- 기존 Jasypt 기반 보안 설정과의 호환성 유지

# 🧩 관련 이슈 (Related Issues)
Closes #2 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * OpenID Connect (OIDC) 인증 지원이 추가되었습니다.

* **Chores**
  * 로깅 기능이 개선되었습니다.
  * 데이터베이스 매핑 구성이 업데이트되었습니다.
  * 코드 포맷팅이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->